### PR TITLE
Unrecognized field "groups"

### DIFF
--- a/src/Gidkom/OpenFireRestApi/OpenFireRestApi.php
+++ b/src/Gidkom/OpenFireRestApi/OpenFireRestApi.php
@@ -51,13 +51,12 @@ class OpenFireRestApi extends RestClient
      * @param   string          $password   Password
      * @param   string|false    $name       Name    (Optional)
      * @param   string|false    $email      Email   (Optional)
-     * @param   string[]|false  $groups     Groups  (Optional)
      * @return  json|false                 Json with data or error, or False when something went fully wrong
      */
-    public function addUser($username, $password, $name=false, $email=false, $groups=false)
+    public function addUser($username, $password, $name=false, $email=false)
     {
         $endpoint = '/users'; 
-        return $this->doRequest('POST', $endpoint, compact('username', 'password','name','email', 'groups'));
+        return $this->doRequest('POST', $endpoint, compact('username', 'password','name','email'));
     }
 
 


### PR DESCRIPTION
Getting:

```
GuzzleHttp\Exception\ServerException: Server error: `POST http://openfire:9090/plugins/restapi/v1/users` resulted in a `500 Server Error` response
```
```
Openfire 4.1.3
REST API Plugin 1.3.1
```

On the server:

```
2018.08.03 08:24:17 org.jivesoftware.openfire.container.PluginServlet - org.codehaus.jackson.map.exc.UnrecognizedPropertyException: Unrecognized field "groups" (Class org.jivesoftware.openfire.plugin.rest.entity.UserEntity), not marked as ignorable
 at [Source: HttpInputOverHTTP@334777bf; line: 1, column: 138] (through reference chain: org.jivesoftware.openfire.plugin.rest.entity.UserEntity["groups"])
javax.servlet.ServletException: org.codehaus.jackson.map.exc.UnrecognizedPropertyException: Unrecognized field "groups" (Class org.jivesoftware.openfire.plugin.rest.entity.UserEntity), not marked as ignorable
 at [Source: HttpInputOverHTTP@334777bf; line: 1, column: 138] (through reference chain: org.jivesoftware.openfire.plugin.rest.entity.UserEntity["groups"])
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:420)
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:558)
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:733)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.jivesoftware.openfire.container.PluginServlet.handleServlet(PluginServlet.java:410)
	at org.jivesoftware.openfire.container.PluginServlet.service(PluginServlet.java:107)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:812)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1669)
	at org.jivesoftware.admin.PluginFilter.doFilter(PluginFilter.java:226)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.jivesoftware.admin.AuthCheckFilter.doFilter(AuthCheckFilter.java:165)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at com.opensymphony.module.sitemesh.filter.PageFilter.parsePage(PageFilter.java:118)
	at com.opensymphony.module.sitemesh.filter.PageFilter.doFilter(PageFilter.java:52)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.codehaus.jackson.map.exc.UnrecognizedPropertyException: Unrecognized field "groups" (Class org.jivesoftware.openfire.plugin.rest.entity.UserEntity), not marked as ignorable
 at [Source: HttpInputOverHTTP@334777bf; line: 1, column: 138] (through reference chain: org.jivesoftware.openfire.plugin.rest.entity.UserEntity["groups"])
	at org.codehaus.jackson.map.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:53)
	at org.codehaus.jackson.map.deser.StdDeserializationContext.unknownFieldException(StdDeserializationContext.java:267)
	at org.codehaus.jackson.map.deser.std.StdDeserializer.reportUnknownProperty(StdDeserializer.java:649)
	at org.codehaus.jackson.map.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:635)
	at org.codehaus.jackson.map.deser.BeanDeserializer.handleUnknownProperty(BeanDeserializer.java:1355)
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:717)
	at org.codehaus.jackson.map.deser.BeanDeserializer.deserialize(BeanDeserializer.java:580)
	at org.codehaus.jackson.map.ObjectMapper._readValue(ObjectMapper.java:2695)
	at org.codehaus.jackson.map.ObjectMapper.readValue(ObjectMapper.java:1308)
	at org.codehaus.jackson.jaxrs.JacksonJsonProvider.readFrom(JacksonJsonProvider.java:419)
	at com.sun.jersey.json.impl.provider.entity.JacksonProviderProxy.readFrom(JacksonProviderProxy.java:139)
	at com.sun.jersey.spi.container.ContainerRequest.getEntity(ContainerRequest.java:490)
	at com.sun.jersey.server.impl.model.method.dispatch.EntityParamDispatchProvider$EntityInjectable.getValue(EntityParamDispatchProvider.java:123)
	at com.sun.jersey.server.impl.inject.InjectableValuesProvider.getInjectableValues(InjectableValuesProvider.java:86)
	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$EntityParamInInvoker.getParams(AbstractResourceMethodDispatchProvider.java:153)
	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$ResponseOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:203)
	at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75)
	at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:302)
	at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:108)
	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
	at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1542)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1473)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1419)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1409)
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:409)
```